### PR TITLE
Fix core-flex="N" feature

### DIFF
--- a/core-layout.css
+++ b/core-layout.css
@@ -84,7 +84,7 @@ body.core-fit {
   flex: none;
 }
 
-.core-flex1, [core-flex=1] {
+.core-flex1, [core-flex="1"] {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   -moz-flex: 1;
@@ -92,7 +92,7 @@ body.core-fit {
   flex: 1;
 }
 
-.core-flex2, [core-flex=2] {
+.core-flex2, [core-flex="2"] {
   -webkit-box-flex: 2;
   -ms-flex: 2;
   -moz-flex: 2;
@@ -100,7 +100,7 @@ body.core-fit {
   flex: 2;
 }
 
-.core-flex3, [core-flex=3] {
+.core-flex3, [core-flex="3"] {
   -webkit-box-flex: 3;
   -ms-flex: 3;
   -moz-flex: 3;
@@ -133,7 +133,7 @@ body.core-fit {
   flex: none;
 }
 
-::content > .core-flex1, ::content > [core-flex=1] {
+::content > .core-flex1, ::content > [core-flex="1"] {
   -webkit-box-flex: 1;
   -ms-flex: 1;
   -moz-flex: 1;
@@ -141,7 +141,7 @@ body.core-fit {
   flex: 1;
 }
 
-::content > .core-flex2, ::content > [core-flex=2] {
+::content > .core-flex2, ::content > [core-flex="2"] {
   -webkit-box-flex: 2;
   -ms-flex: 2;
   -moz-flex: 2;
@@ -149,7 +149,7 @@ body.core-fit {
   flex: 2;
 }
 
-::content > .core-flex3, ::content > [core-flex=3] {
+::content > .core-flex3, ::content > [core-flex="3"] {
   -webkit-box-flex: 3;
   -ms-flex: 3;
   -moz-flex: 3;

--- a/demo.html
+++ b/demo.html
@@ -52,8 +52,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </style>
       <core-layout></core-layout>
       <core-layout core-flex>
-        <div>Hi I'm some content</div>
-        <core-layout core-flex vertical>
+        <div core-flex="1">Hi I'm some content</div>
+        <core-layout core-flex="3" vertical>
           <core-layout align="center">
             <h3>Title</h3>
             <button>hello</button>
@@ -70,7 +70,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             <b>Footer</b>
           </core-layout>
         </core-layout>
-        <div>A last bit, like a panel</div>
+        <div core-flex="1">A last bit, like a panel</div>
       </core-layout>
     </template>
   </polymer-element>


### PR DESCRIPTION
`core-flex="N"` was not working properly for me. Adding double quotes to the attribute selectors seems to fix this feature. I've updated the demo to use this feature.
